### PR TITLE
Add Claude authentication status to /claudestatus command

### DIFF
--- a/src/commands/claude_status.rs
+++ b/src/commands/claude_status.rs
@@ -6,30 +6,63 @@ pub async fn handle_claude_status(bot: Bot, msg: Message, bot_state: BotState, c
     let container_name = format!("coding-session-{}", chat_id);
 
     match ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name).await {
-        Ok(client) => match client.check_availability().await {
-            Ok(version) => {
-                bot.send_message(
-                    msg.chat.id,
-                    format!(
-                        "✅ Claude Code is available\\!\n\n*Version:* `{}`",
-                        escape_markdown_v2(&version)
-                    ),
-                )
-                .parse_mode(ParseMode::MarkdownV2)
-                .await?;
+        Ok(client) => {
+            // Check Claude Code availability
+            let version_result = client.check_availability().await;
+            // Check Claude authentication status
+            let auth_result = client.get_auth_info().await;
+
+            match (version_result, auth_result) {
+                (Ok(version), Ok(auth_info)) => {
+                    bot.send_message(
+                        msg.chat.id,
+                        format!(
+                            "✅ *Claude Code Status*\n\n*Version:* `{}`\n\n*Authentication:* {}",
+                            escape_markdown_v2(&version),
+                            escape_markdown_v2(&auth_info)
+                        ),
+                    )
+                    .parse_mode(ParseMode::MarkdownV2)
+                    .await?;
+                }
+                (Ok(version), Err(auth_err)) => {
+                    bot.send_message(
+                        msg.chat.id,
+                        format!(
+                            "✅ *Claude Code Status*\n\n*Version:* `{}`\n\n❌ *Authentication Error:* {}",
+                            escape_markdown_v2(&version),
+                            escape_markdown_v2(&auth_err.to_string())
+                        ),
+                    )
+                    .parse_mode(ParseMode::MarkdownV2)
+                    .await?;
+                }
+                (Err(version_err), Ok(auth_info)) => {
+                    bot.send_message(
+                        msg.chat.id,
+                        format!(
+                            "❌ *Claude Code Status*\n\n*Version Check Failed:* {}\n\n*Authentication:* {}",
+                            escape_markdown_v2(&version_err.to_string()),
+                            escape_markdown_v2(&auth_info)
+                        ),
+                    )
+                    .parse_mode(ParseMode::MarkdownV2)
+                    .await?;
+                }
+                (Err(version_err), Err(auth_err)) => {
+                    bot.send_message(
+                        msg.chat.id,
+                        format!(
+                            "❌ *Claude Code Status*\n\n*Version Check Failed:* {}\n\n*Authentication Check Failed:* {}",
+                            escape_markdown_v2(&version_err.to_string()),
+                            escape_markdown_v2(&auth_err.to_string())
+                        ),
+                    )
+                    .parse_mode(ParseMode::MarkdownV2)
+                    .await?;
+                }
             }
-            Err(e) => {
-                bot.send_message(
-                    msg.chat.id,
-                    format!(
-                        "❌ Claude Code check failed: {}",
-                        escape_markdown_v2(&e.to_string())
-                    ),
-                )
-                .parse_mode(ParseMode::MarkdownV2)
-                .await?;
-            }
-        },
+        }
         Err(e) => {
             bot.send_message(
                 msg.chat.id,


### PR DESCRIPTION
## Summary

Enhanced the `/claudestatus` bot command to display both Claude Code version and authentication status information. This provides users with complete visibility into their Claude Code setup.

### Changes Made

- Added authentication status checking using `get_auth_info()` method from `ClaudeCodeClient`
- Enhanced response format to show both version and authentication status
- Improved error handling for both version check and authentication check scenarios
- Updated message format with proper MarkdownV2 escaping for clean display

### Example Output

Before:
```
✅ Claude Code is available\!

Version: claude-code-v1.2.3
```

After:
```
✅ Claude Code Status

Version: claude-code-v1.2.3

Authentication: ✅ Claude Code is authenticated and ready to use
```

## Test Plan

- [x] Code compiles successfully with `cargo check` and `cargo build`
- [x] Existing Claude status test passes: `test_claude_status_command_with_preinstalled_claude`
- [x] All existing functionality preserved
- [x] Enhanced status command provides both version and auth information
- [x] Proper error handling for both success and failure scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)