### PR TITLE
Fix: Prevent premature cancellation of Claude OAuth flow

### DIFF
--- a/src/commands/authenticate_claude.rs
+++ b/src/commands/authenticate_claude.rs
@@ -58,13 +58,14 @@ pub async fn handle_claude_authentication(
                     let AuthenticationHandle {
                         state_receiver,
                         code_sender,
-                        cancel_sender: _cancel_sender,
+                        cancel_sender, // No longer prefixed with _
                     } = auth_handle;
 
                     // Store authentication session
                     let session = AuthSession {
                         container_name: container_name.clone(),
                         code_sender: code_sender.clone(),
+                        cancel_sender, // Store the cancel_sender
                     };
 
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use teloxide::{
     types::{CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, ParseMode},
     utils::command::BotCommands,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot, mpsc};
 use url::Url;
 
 mod commands;
@@ -20,7 +20,6 @@ use telegram_bot::claude_code_client::{
     container_utils, AuthState, ClaudeCodeClient,
     GithubClient, GithubClientConfig,
 };
-use tokio::sync::mpsc;
 
 /// Escape reserved characters for Telegram MarkdownV2 formatting
 /// According to Telegram's MarkdownV2 spec, these characters must be escaped:
@@ -80,6 +79,7 @@ enum Command {
 struct AuthSession {
     container_name: String,
     code_sender: mpsc::UnboundedSender<String>,
+    cancel_sender: oneshot::Sender<()>,
 }
 
 // Global state for tracking authentication sessions


### PR DESCRIPTION
The OAuth flow was being cancelled prematurely because the `cancel_sender` (oneshot::Sender) was being dropped immediately after the `AuthenticationHandle` was destructured in `commands::handle_claude_authentication`.

This commit fixes the issue by:
1. Adding a `cancel_sender` field to the `AuthSession` struct in `main.rs`.
2. Storing the `cancel_sender` in the `AuthSession` when an authentication process is initiated.

This ensures the `cancel_sender` remains alive as long as the authentication session is active, preventing the `background_oauth_flow` from detecting a cancellation signal due to an early drop. The flow will now correctly wait for user input or timeout.