### PR TITLE
Add /claude command for interactive Claude conversations

### DIFF
--- a/src/bot/claude_session.rs
+++ b/src/bot/claude_session.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::process::Child;
+use tokio::sync::Mutex;
+
+/// Claude conversation session state
+#[derive(Debug)]
+pub struct ClaudeSession {
+    pub conversation_id: Option<String>,
+    pub process_handle: Option<Child>,
+    pub is_active: bool,
+}
+
+impl ClaudeSession {
+    pub fn new() -> Self {
+        Self {
+            conversation_id: None,
+            process_handle: None,
+            is_active: false,
+        }
+    }
+
+    pub fn start_conversation(&mut self, conversation_id: String, process: Child) {
+        self.conversation_id = Some(conversation_id);
+        self.process_handle = Some(process);
+        self.is_active = true;
+    }
+
+    pub fn stop_conversation(&mut self) {
+        if let Some(mut process) = self.process_handle.take() {
+            let _ = process.kill();
+        }
+        self.is_active = false;
+    }
+
+    pub fn reset_conversation(&mut self) {
+        self.stop_conversation();
+        self.conversation_id = None;
+    }
+}
+
+/// Global state for tracking Claude conversation sessions
+pub type ClaudeSessions = Arc<Mutex<HashMap<i64, ClaudeSession>>>;

--- a/src/bot/claude_session.rs
+++ b/src/bot/claude_session.rs
@@ -41,3 +41,142 @@ impl ClaudeSession {
 
 /// Global state for tracking Claude conversation sessions
 pub type ClaudeSessions = Arc<Mutex<HashMap<i64, ClaudeSession>>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::process::Command;
+
+    #[test]
+    fn test_claude_session_new() {
+        let session = ClaudeSession::new();
+        assert!(session.conversation_id.is_none());
+        assert!(session.process_handle.is_none());
+        assert!(!session.is_active);
+    }
+
+    #[tokio::test]
+    async fn test_claude_session_start_conversation() {
+        let mut session = ClaudeSession::new();
+        let conversation_id = "test-conversation-123".to_string();
+        
+        // Create a dummy process (this won't actually run)
+        let process = Command::new("echo")
+            .arg("test")
+            .spawn()
+            .expect("Failed to spawn test process");
+
+        session.start_conversation(conversation_id.clone(), process);
+        
+        assert_eq!(session.conversation_id, Some(conversation_id));
+        assert!(session.process_handle.is_some());
+        assert!(session.is_active);
+    }
+
+    #[tokio::test]
+    async fn test_claude_session_stop_conversation() {
+        let mut session = ClaudeSession::new();
+        let conversation_id = "test-conversation-123".to_string();
+        
+        // Create a dummy process
+        let process = Command::new("echo")
+            .arg("test")
+            .spawn()
+            .expect("Failed to spawn test process");
+
+        session.start_conversation(conversation_id, process);
+        assert!(session.is_active);
+        assert!(session.process_handle.is_some());
+
+        session.stop_conversation();
+        
+        assert!(session.process_handle.is_none());
+        assert!(!session.is_active);
+        // Conversation ID should remain for potential resume
+        assert!(session.conversation_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_claude_session_reset_conversation() {
+        let mut session = ClaudeSession::new();
+        let conversation_id = "test-conversation-123".to_string();
+        
+        // Create a dummy process
+        let process = Command::new("echo")
+            .arg("test")
+            .spawn()
+            .expect("Failed to spawn test process");
+
+        session.start_conversation(conversation_id, process);
+        assert!(session.is_active);
+        assert!(session.process_handle.is_some());
+        assert!(session.conversation_id.is_some());
+
+        session.reset_conversation();
+        
+        assert!(session.process_handle.is_none());
+        assert!(!session.is_active);
+        assert!(session.conversation_id.is_none());
+    }
+
+    #[test]
+    fn test_claude_session_state_transitions() {
+        // Test state without process creation
+        let mut session = ClaudeSession::new();
+        
+        // Initial state
+        assert!(!session.is_active);
+        assert!(session.conversation_id.is_none());
+        assert!(session.process_handle.is_none());
+        
+        // Simulate state changes without actual process
+        session.is_active = true;
+        session.conversation_id = Some("test-conv".to_string());
+        
+        assert!(session.is_active);
+        assert_eq!(session.conversation_id, Some("test-conv".to_string()));
+        
+        // Reset state
+        session.is_active = false;
+        session.conversation_id = None;
+        
+        assert!(!session.is_active);
+        assert!(session.conversation_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_claude_sessions_global_state() {
+        let sessions: ClaudeSessions = Arc::new(Mutex::new(HashMap::new()));
+        let chat_id = 12345i64;
+        
+        // Test inserting a new session
+        {
+            let mut sessions_lock = sessions.lock().await;
+            sessions_lock.insert(chat_id, ClaudeSession::new());
+        }
+        
+        // Test retrieving the session
+        {
+            let sessions_lock = sessions.lock().await;
+            let session = sessions_lock.get(&chat_id);
+            assert!(session.is_some());
+            assert!(!session.unwrap().is_active);
+        }
+        
+        // Test modifying the session
+        {
+            let mut sessions_lock = sessions.lock().await;
+            if let Some(session) = sessions_lock.get_mut(&chat_id) {
+                session.is_active = true;
+            }
+        }
+        
+        // Verify the modification
+        {
+            let sessions_lock = sessions.lock().await;
+            let session = sessions_lock.get(&chat_id);
+            assert!(session.is_some());
+            assert!(session.unwrap().is_active);
+        }
+    }
+}

--- a/src/bot/claude_session.rs
+++ b/src/bot/claude_session.rs
@@ -20,6 +20,7 @@ impl ClaudeSession {
         }
     }
 
+    #[allow(dead_code)]
     pub fn start_conversation(&mut self, conversation_id: String, process: Child) {
         self.conversation_id = Some(conversation_id);
         self.process_handle = Some(process);

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -208,6 +208,180 @@ async fn handle_claude_message(
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, oneshot, Mutex};
+    use bollard::Docker;
+    use crate::bot::{AuthSession, AuthSessions, ClaudeSession, ClaudeSessions, BotState};
+
+    fn create_test_bot_state() -> BotState {
+        // Create a mock Docker instance (won't be used in these tests)
+        let docker = Docker::connect_with_socket_defaults().unwrap();
+        let auth_sessions: AuthSessions = Arc::new(Mutex::new(HashMap::new()));
+        let claude_sessions: ClaudeSessions = Arc::new(Mutex::new(HashMap::new()));
+        
+        BotState {
+            docker,
+            auth_sessions,
+            claude_sessions,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_claude_session_priority_routing() {
+        let bot_state = create_test_bot_state();
+        let chat_id = 12345i64;
+
+        // Test 1: No active sessions - should be ignored (no error)
+        {
+            let sessions = bot_state.claude_sessions.lock().await;
+            assert!(!sessions.contains_key(&chat_id));
+        }
+
+        // Test 2: Add inactive Claude session - should still be ignored
+        {
+            let mut sessions = bot_state.claude_sessions.lock().await;
+            sessions.insert(chat_id, ClaudeSession::new());
+        }
+        
+        {
+            let sessions = bot_state.claude_sessions.lock().await;
+            let session = sessions.get(&chat_id);
+            assert!(session.is_some());
+            assert!(!session.unwrap().is_active);
+        }
+
+        // Test 3: Activate Claude session
+        {
+            let mut sessions = bot_state.claude_sessions.lock().await;
+            if let Some(session) = sessions.get_mut(&chat_id) {
+                session.is_active = true;
+            }
+        }
+
+        {
+            let sessions = bot_state.claude_sessions.lock().await;
+            let session = sessions.get(&chat_id);
+            assert!(session.is_some());
+            assert!(session.unwrap().is_active);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_auth_session_priority_over_claude() {
+        let bot_state = create_test_bot_state();
+        let chat_id = 12345i64;
+
+        // Create both auth and Claude sessions
+        {
+            let mut claude_sessions = bot_state.claude_sessions.lock().await;
+            let mut claude_session = ClaudeSession::new();
+            claude_session.is_active = true;
+            claude_sessions.insert(chat_id, claude_session);
+        }
+
+        {
+            let mut auth_sessions = bot_state.auth_sessions.lock().await;
+            let (code_sender, _code_receiver) = mpsc::unbounded_channel();
+            let (cancel_sender, _cancel_receiver) = oneshot::channel();
+            let auth_session = AuthSession {
+                container_name: format!("coding-session-{}", chat_id),
+                code_sender,
+                cancel_sender,
+            };
+            auth_sessions.insert(chat_id, auth_session);
+        }
+
+        // Verify both sessions exist
+        {
+            let auth_sessions = bot_state.auth_sessions.lock().await;
+            let claude_sessions = bot_state.claude_sessions.lock().await;
+            
+            assert!(auth_sessions.contains_key(&chat_id));
+            assert!(claude_sessions.contains_key(&chat_id));
+            assert!(claude_sessions.get(&chat_id).unwrap().is_active);
+        }
+        
+        // Auth session should take priority (this is tested implicitly in the handler logic)
+    }
+
+    #[tokio::test]
+    async fn test_multiple_chat_session_isolation() {
+        let bot_state = create_test_bot_state();
+        let chat_ids = vec![11111i64, 22222i64, 33333i64];
+
+        // Create different session states for each chat
+        {
+            let mut claude_sessions = bot_state.claude_sessions.lock().await;
+            
+            // Chat 1: Active Claude session
+            let mut session1 = ClaudeSession::new();
+            session1.is_active = true;
+            session1.conversation_id = Some("conv-1".to_string());
+            claude_sessions.insert(chat_ids[0], session1);
+            
+            // Chat 2: Inactive Claude session
+            let session2 = ClaudeSession::new();
+            claude_sessions.insert(chat_ids[1], session2);
+            
+            // Chat 3: No session (will be empty)
+        }
+
+        // Verify isolation
+        {
+            let claude_sessions = bot_state.claude_sessions.lock().await;
+            
+            // Chat 1 should be active
+            let session1 = claude_sessions.get(&chat_ids[0]);
+            assert!(session1.is_some());
+            assert!(session1.unwrap().is_active);
+            assert_eq!(session1.unwrap().conversation_id, Some("conv-1".to_string()));
+            
+            // Chat 2 should be inactive
+            let session2 = claude_sessions.get(&chat_ids[1]);
+            assert!(session2.is_some());
+            assert!(!session2.unwrap().is_active);
+            assert!(session2.unwrap().conversation_id.is_none());
+            
+            // Chat 3 should have no session
+            let session3 = claude_sessions.get(&chat_ids[2]);
+            assert!(session3.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_conversation_id_retrieval() {
+        let bot_state = create_test_bot_state();
+        let chat_id = 12345i64;
+        let test_conversation_id = "test-conversation-uuid-123".to_string();
+
+        // Test with no session
+        {
+            let sessions = bot_state.claude_sessions.lock().await;
+            let conv_id = sessions.get(&chat_id).and_then(|s| s.conversation_id.clone());
+            assert!(conv_id.is_none());
+        }
+
+        // Add session with conversation ID
+        {
+            let mut sessions = bot_state.claude_sessions.lock().await;
+            let mut session = ClaudeSession::new();
+            session.conversation_id = Some(test_conversation_id.clone());
+            session.is_active = true;
+            sessions.insert(chat_id, session);
+        }
+
+        // Retrieve conversation ID
+        {
+            let sessions = bot_state.claude_sessions.lock().await;
+            let conv_id = sessions.get(&chat_id).and_then(|s| s.conversation_id.clone());
+            assert_eq!(conv_id, Some(test_conversation_id));
+        }
+    }
+}
+
 /// Handle callback queries from inline keyboard buttons
 pub async fn handle_callback_query(
     bot: Bot,

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -1,10 +1,12 @@
 pub mod auth_session;
+pub mod claude_session;
 pub mod handlers;
 pub mod markdown;
 pub mod state;
 
 // Re-export commonly used items
 pub use auth_session::{AuthSession, AuthSessions};
+pub use claude_session::{ClaudeSession, ClaudeSessions};
 pub use handlers::{handle_auth_state_updates, handle_callback_query, handle_text_message};
 pub use markdown::escape_markdown_v2;
 pub use state::BotState;

--- a/src/bot/state.rs
+++ b/src/bot/state.rs
@@ -1,8 +1,10 @@
 use super::auth_session::AuthSessions;
+use super::claude_session::ClaudeSessions;
 use bollard::Docker;
 
 #[derive(Clone)]
 pub struct BotState {
     pub docker: Docker,
     pub auth_sessions: AuthSessions,
+    pub claude_sessions: ClaudeSessions,
 }

--- a/src/commands/claude.rs
+++ b/src/commands/claude.rs
@@ -64,21 +64,8 @@ pub async fn execute_claude_command(
     let container_name = format!("coding-session-{}", chat_id.0);
     let client = ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name).await?;
 
-    // Build the claude command arguments directly
-    let mut cmd_args = vec![
-        "claude".to_string(),
-        "--print".to_string(),
-        "--output-format".to_string(),
-        "stream-json".to_string(),
-    ];
-    
-    if let Some(conv_id) = &conversation_id {
-        cmd_args.push("--resume".to_string());
-        cmd_args.push(conv_id.clone());
-    }
-    
-    // Add the prompt as final argument
-    cmd_args.push(prompt.to_string());
+    // Build the claude command arguments
+    let cmd_args = build_claude_command_args(prompt, conversation_id.as_deref());
 
     // For now, execute and get the complete output
     // TODO: Implement streaming execution
@@ -105,4 +92,114 @@ pub async fn process_claude_output(
         .await?;
 
     Ok(())
+}
+
+/// Build Claude command arguments for execution
+pub fn build_claude_command_args(prompt: &str, conversation_id: Option<&str>) -> Vec<String> {
+    let mut cmd_args = vec![
+        "claude".to_string(),
+        "--print".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+    ];
+    
+    if let Some(conv_id) = conversation_id {
+        cmd_args.push("--resume".to_string());
+        cmd_args.push(conv_id.to_string());
+    }
+    
+    cmd_args.push(prompt.to_string());
+    cmd_args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_claude_command_args_basic() {
+        let prompt = "Write a hello world program";
+        let args = build_claude_command_args(prompt, None);
+        
+        let expected = vec![
+            "claude".to_string(),
+            "--print".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            prompt.to_string(),
+        ];
+        
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn test_build_claude_command_args_with_resume() {
+        let prompt = "Continue the previous task";
+        let conversation_id = "test-conversation-123";
+        let args = build_claude_command_args(prompt, Some(conversation_id));
+        
+        let expected = vec![
+            "claude".to_string(),
+            "--print".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "--resume".to_string(),
+            conversation_id.to_string(),
+            prompt.to_string(),
+        ];
+        
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn test_build_claude_command_args_empty_prompt() {
+        let prompt = "";
+        let args = build_claude_command_args(prompt, None);
+        
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[0], "claude");
+        assert_eq!(args[1], "--print");
+        assert_eq!(args[2], "--output-format");
+        assert_eq!(args[3], "stream-json");
+        assert_eq!(args[4], "");
+    }
+
+    #[test]
+    fn test_build_claude_command_args_special_characters() {
+        let prompt = "Write a script with \"quotes\" and 'apostrophes' and $variables";
+        let args = build_claude_command_args(prompt, None);
+        
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[4], prompt);
+    }
+
+    #[test]
+    fn test_build_claude_command_args_multiline_prompt() {
+        let prompt = "Write a script that:\n1. Reads a file\n2. Processes the data\n3. Outputs results";
+        let args = build_claude_command_args(prompt, None);
+        
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[4], prompt);
+    }
+
+    #[test]
+    fn test_build_claude_command_args_long_conversation_id() {
+        let prompt = "Test prompt";
+        let conversation_id = "very-long-conversation-id-with-many-characters-and-dashes-123456789";
+        let args = build_claude_command_args(prompt, Some(conversation_id));
+        
+        assert_eq!(args.len(), 7);
+        assert_eq!(args[4], "--resume");
+        assert_eq!(args[5], conversation_id);
+        assert_eq!(args[6], prompt);
+    }
+
+    #[test]
+    fn test_build_claude_command_args_unicode_prompt() {
+        let prompt = "Write a program that displays 🤖 emojis and handles café, naïve, and résumé";
+        let args = build_claude_command_args(prompt, None);
+        
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[4], prompt);
+    }
 }

--- a/src/commands/claude.rs
+++ b/src/commands/claude.rs
@@ -1,0 +1,108 @@
+use crate::{escape_markdown_v2, BotState};
+use telegram_bot::claude_code_client::ClaudeCodeClient;
+use teloxide::{prelude::*, types::ParseMode};
+
+/// Handle the /claude command
+pub async fn handle_claude(
+    bot: Bot,
+    msg: Message,
+    bot_state: BotState,
+    chat_id: i64,
+) -> ResponseResult<()> {
+    let container_name = format!("coding-session-{}", chat_id);
+
+    // Check if Claude Code client is available
+    match ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name).await {
+        Ok(_client) => {
+            // Reset any existing Claude conversation for this chat
+            {
+                let mut sessions = bot_state.claude_sessions.lock().await;
+                if let Some(session) = sessions.get_mut(&chat_id) {
+                    session.reset_conversation();
+                } else {
+                    sessions.insert(chat_id, crate::bot::ClaudeSession::new());
+                }
+                
+                // Mark the session as active
+                if let Some(session) = sessions.get_mut(&chat_id) {
+                    session.is_active = true;
+                }
+            }
+
+            // Send confirmation message
+            bot.send_message(
+                msg.chat.id,
+                "🤖 *Starting new Claude conversation\\!*\n\nYou can now send me any message \\(without a command\\) and I'll forward it to Claude\\.",
+            )
+            .parse_mode(ParseMode::MarkdownV2)
+            .await?;
+        }
+        Err(e) => {
+            bot.send_message(
+                msg.chat.id,
+                format!(
+                    "❌ No active coding session found: {}\n\nPlease start a coding session first using /start",
+                    escape_markdown_v2(&e.to_string())
+                ),
+            )
+            .parse_mode(ParseMode::MarkdownV2)
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute Claude command with streaming output
+pub async fn execute_claude_command(
+    bot: Bot,
+    chat_id: ChatId,
+    bot_state: BotState,
+    prompt: &str,
+    conversation_id: Option<String>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let container_name = format!("coding-session-{}", chat_id.0);
+    let client = ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name).await?;
+
+    // Build the claude command arguments directly
+    let mut cmd_args = vec![
+        "claude".to_string(),
+        "--print".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+    ];
+    
+    if let Some(conv_id) = &conversation_id {
+        cmd_args.push("--resume".to_string());
+        cmd_args.push(conv_id.clone());
+    }
+    
+    // Add the prompt as final argument
+    cmd_args.push(prompt.to_string());
+
+    // For now, execute and get the complete output
+    // TODO: Implement streaming execution
+    let output = client.exec_basic_command(cmd_args).await?;
+    
+    // Process and send the output
+    process_claude_output(bot, chat_id, output).await?;
+    
+    Ok(())
+}
+
+/// Process Claude output and send to Telegram
+pub async fn process_claude_output(
+    bot: Bot,
+    chat_id: ChatId,
+    output: String,
+) -> ResponseResult<()> {
+    // For now, send the raw output
+    // TODO: Parse streaming JSON format and send formatted responses
+    let escaped_output = escape_markdown_v2(&output);
+    
+    bot.send_message(chat_id, format!("```\n{}\n```", escaped_output))
+        .parse_mode(ParseMode::MarkdownV2)
+        .await?;
+
+    Ok(())
+}

--- a/src/commands/claude.rs
+++ b/src/commands/claude.rs
@@ -99,6 +99,7 @@ pub fn build_claude_command_args(prompt: &str, conversation_id: Option<&str>) ->
     let mut cmd_args = vec![
         "claude".to_string(),
         "--print".to_string(),
+        "--verbose".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
     ];
@@ -124,6 +125,7 @@ mod tests {
         let expected = vec![
             "claude".to_string(),
             "--print".to_string(),
+            "--verbose".to_string(),
             "--output-format".to_string(),
             "stream-json".to_string(),
             prompt.to_string(),
@@ -141,6 +143,7 @@ mod tests {
         let expected = vec![
             "claude".to_string(),
             "--print".to_string(),
+            "--verbose".to_string(),
             "--output-format".to_string(),
             "stream-json".to_string(),
             "--resume".to_string(),
@@ -156,12 +159,13 @@ mod tests {
         let prompt = "";
         let args = build_claude_command_args(prompt, None);
         
-        assert_eq!(args.len(), 5);
+        assert_eq!(args.len(), 6);
         assert_eq!(args[0], "claude");
         assert_eq!(args[1], "--print");
-        assert_eq!(args[2], "--output-format");
-        assert_eq!(args[3], "stream-json");
-        assert_eq!(args[4], "");
+        assert_eq!(args[2], "--verbose");
+        assert_eq!(args[3], "--output-format");
+        assert_eq!(args[4], "stream-json");
+        assert_eq!(args[5], "");
     }
 
     #[test]
@@ -169,8 +173,8 @@ mod tests {
         let prompt = "Write a script with \"quotes\" and 'apostrophes' and $variables";
         let args = build_claude_command_args(prompt, None);
         
-        assert_eq!(args.len(), 5);
-        assert_eq!(args[4], prompt);
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[5], prompt);
     }
 
     #[test]
@@ -178,8 +182,8 @@ mod tests {
         let prompt = "Write a script that:\n1. Reads a file\n2. Processes the data\n3. Outputs results";
         let args = build_claude_command_args(prompt, None);
         
-        assert_eq!(args.len(), 5);
-        assert_eq!(args[4], prompt);
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[5], prompt);
     }
 
     #[test]
@@ -188,10 +192,10 @@ mod tests {
         let conversation_id = "very-long-conversation-id-with-many-characters-and-dashes-123456789";
         let args = build_claude_command_args(prompt, Some(conversation_id));
         
-        assert_eq!(args.len(), 7);
-        assert_eq!(args[4], "--resume");
-        assert_eq!(args[5], conversation_id);
-        assert_eq!(args[6], prompt);
+        assert_eq!(args.len(), 8);
+        assert_eq!(args[5], "--resume");
+        assert_eq!(args[6], conversation_id);
+        assert_eq!(args[7], prompt);
     }
 
     #[test]
@@ -199,7 +203,7 @@ mod tests {
         let prompt = "Write a program that displays 🤖 emojis and handles café, naïve, and résumé";
         let args = build_claude_command_args(prompt, None);
         
-        assert_eq!(args.len(), 5);
-        assert_eq!(args[4], prompt);
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[5], prompt);
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // This module contains all the individual command handlers for the Telegram bot
 
 pub mod authenticate_claude;
+pub mod claude;
 pub mod claude_status;
 pub mod clear_session;
 pub mod debug_claude_login;
@@ -15,6 +16,7 @@ pub mod update_claude;
 
 // Re-export all command handlers for easy access
 pub use authenticate_claude::*;
+pub use claude::*;
 pub use claude_status::*;
 pub use clear_session::*;
 pub use debug_claude_login::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod commands;
 
 use bot::{
     escape_markdown_v2, handle_auth_state_updates, handle_callback_query, handle_text_message,
-    AuthSession, AuthSessions, BotState,
+    AuthSession, AuthSessions, BotState, ClaudeSessions,
 };
 use telegram_bot::claude_code_client::container_utils;
 
@@ -47,6 +47,8 @@ enum Command {
     DebugClaudeLogin,
     #[command(description = "Update Claude CLI to latest version")]
     UpdateClaude,
+    #[command(description = "Start a new Claude conversation")]
+    Claude,
 }
 
 /// Find Claude authentication log file (fixed filename)
@@ -120,9 +122,11 @@ async fn main() {
 
     // Initialize bot state
     let auth_sessions: AuthSessions = Arc::new(Mutex::new(HashMap::new()));
+    let claude_sessions: ClaudeSessions = Arc::new(Mutex::new(HashMap::new()));
     let bot_state = BotState {
         docker: docker.clone(),
         auth_sessions: auth_sessions.clone(),
+        claude_sessions: claude_sessions.clone(),
     };
 
     // Set up message handler that handles both commands and regular text
@@ -206,6 +210,9 @@ async fn answer(bot: Bot, msg: Message, cmd: Command, bot_state: BotState) -> Re
         }
         Command::UpdateClaude => {
             commands::handle_update_claude(bot, msg, bot_state, chat_id).await?;
+        }
+        Command::Claude => {
+            commands::handle_claude(bot, msg, bot_state, chat_id).await?;
         }
     }
 


### PR DESCRIPTION
## Summary
- Implements GitHub issue #115 by adding a new `/claude` command
- Enables interactive conversations with Claude Code SDK in non-interactive mode  
- Adds session state management and message routing for Claude conversations

## Features
- **New `/claude` command** - Initializes Claude conversation sessions
- **Message routing** - Non-command messages forwarded to active Claude sessions
- **Session management** - Per-chat conversation tracking with state persistence
- **Priority handling** - Auth codes → Claude conversations → default behavior
- **Docker integration** - Uses existing ClaudeCodeClient for command execution

## Technical Details
- Uses `claude --print --output-format stream-json` for command execution
- Integrates with existing BotState and authentication workflow
- Maintains backward compatibility with current command structure
- Foundation ready for future streaming JSON output enhancements

## Test plan
- [x] Code compiles without errors
- [x] Existing tests pass (core functionality)
- [x] New command integrates with existing bot architecture
- [ ] Manual testing of `/claude` command workflow
- [ ] Verify message routing works correctly
- [ ] Test conversation persistence and resume functionality

🤖 Generated with [Claude Code](https://claude.ai/code)