### PR TITLE
refactor: Move Claude streaming types to claude_code_client module

### DIFF
--- a/src/bot/markdown.rs
+++ b/src/bot/markdown.rs
@@ -13,6 +13,7 @@ pub fn escape_markdown_v2(text: &str) -> String {
         .collect()
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,4 +93,5 @@ mod tests {
         let formatted = format!("```{}```", escape_markdown_v2(code));
         assert_eq!(formatted, "```ABC\\-123```");
     }
+
 }

--- a/src/claude_code_client/mod.rs
+++ b/src/claude_code_client/mod.rs
@@ -8,6 +8,7 @@ pub mod container_cred_storage;
 pub mod container_utils;
 pub mod executor;
 pub mod github_client;
+pub mod streaming;
 
 pub use auth::{AuthState, AuthenticationHandle};
 pub use config::ClaudeCodeConfig;
@@ -15,6 +16,7 @@ pub use container_cred_storage::ContainerCredStorage;
 pub use executor::CommandExecutor;
 #[allow(unused_imports)]
 pub use github_client::{GithubAuthResult, GithubClient, GithubClientConfig, GithubCloneResult};
+pub use streaming::{AssistantMessage, ClaudeMessage, ContentBlock, ToolResult, UserMessage};
 
 // Re-export OAuth types from oauth module
 pub use crate::oauth::{ClaudeAuth, Config as OAuthConfig, Credentials, OAuthError};

--- a/src/claude_code_client/streaming.rs
+++ b/src/claude_code_client/streaming.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+
+/// Claude CLI streaming JSON message types
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum ClaudeMessage {
+    #[serde(rename = "system")]
+    System {
+        subtype: String,
+        #[serde(default)]
+        cwd: Option<String>,
+        #[serde(default)]
+        session_id: Option<String>,
+        #[serde(default)]
+        tools: Option<Vec<String>>,
+        #[serde(default)]
+        model: Option<String>,
+    },
+    #[serde(rename = "assistant")]
+    Assistant {
+        message: AssistantMessage,
+        #[serde(default)]
+        session_id: Option<String>,
+    },
+    #[serde(rename = "user")]
+    User {
+        message: UserMessage,
+        #[serde(default)]
+        session_id: Option<String>,
+    },
+    #[serde(rename = "result")]
+    Result {
+        subtype: String,
+        is_error: bool,
+        result: String,
+        session_id: String,
+        #[serde(default)]
+        total_cost_usd: Option<f64>,
+        #[serde(default)]
+        duration_ms: Option<u64>,
+        #[serde(default)]
+        num_turns: Option<u32>,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AssistantMessage {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub content: Option<Vec<ContentBlock>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UserMessage {
+    #[serde(default)]
+    pub content: Option<Vec<ToolResult>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: Option<serde_json::Value>,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ToolResult {
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    #[serde(default)]
+    pub content: Option<String>,
+}

--- a/src/commands/claude.rs
+++ b/src/commands/claude.rs
@@ -1,14 +1,39 @@
-use crate::{escape_markdown_v2, BotState};
+use crate::bot::markdown::escape_markdown_v2;
+use crate::BotState;
 use futures_util::StreamExt;
-use serde::{Deserialize, Serialize};
 use serde_json;
 use std::time::{Duration, Instant};
-use telegram_bot::claude_code_client::ClaudeCodeClient;
+use telegram_bot::claude_code_client::{ClaudeCodeClient, ClaudeMessage, ContentBlock};
 use teloxide::{
     prelude::*,
     types::{MessageId, ParseMode},
 };
 use tokio::time;
+
+/// Maximum number of lines to show in tool result preview
+const TOOL_RESULT_PREVIEW_LINES: usize = 20;
+
+/// Create a truncated preview of tool result content
+fn create_tool_result_preview(content: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    
+    if lines.len() <= TOOL_RESULT_PREVIEW_LINES {
+        // Content is short enough, show it all
+        format!("📋 *Tool result:*\n```\n{}\n```", escape_markdown_v2(content))
+    } else {
+        // Content is too long, show preview with truncation indicator
+        let preview_lines = &lines[0..TOOL_RESULT_PREVIEW_LINES];
+        let preview_content = preview_lines.join("\n");
+        let remaining_lines = lines.len() - TOOL_RESULT_PREVIEW_LINES;
+        
+        format!(
+            "📋 *Tool result \\(showing first {} lines, {} more lines hidden\\):*\n```\n{}\n\\.\\.\\.\n```",
+            TOOL_RESULT_PREVIEW_LINES,
+            remaining_lines,
+            escape_markdown_v2(&preview_content)
+        )
+    }
+}
 
 /// Live message state for real-time updates
 #[derive(Debug)]
@@ -48,84 +73,6 @@ impl LiveMessage {
     }
 }
 
-/// Claude CLI streaming JSON message types
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "type")]
-enum ClaudeMessage {
-    #[serde(rename = "system")]
-    System {
-        subtype: String,
-        #[serde(default)]
-        cwd: Option<String>,
-        #[serde(default)]
-        session_id: Option<String>,
-        #[serde(default)]
-        tools: Option<Vec<String>>,
-        #[serde(default)]
-        model: Option<String>,
-    },
-    #[serde(rename = "assistant")]
-    Assistant {
-        message: AssistantMessage,
-        #[serde(default)]
-        session_id: Option<String>,
-    },
-    #[serde(rename = "user")]
-    User {
-        message: UserMessage,
-        #[serde(default)]
-        session_id: Option<String>,
-    },
-    #[serde(rename = "result")]
-    Result {
-        subtype: String,
-        is_error: bool,
-        result: String,
-        session_id: String,
-        #[serde(default)]
-        total_cost_usd: Option<f64>,
-        #[serde(default)]
-        duration_ms: Option<u64>,
-        #[serde(default)]
-        num_turns: Option<u32>,
-    },
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct AssistantMessage {
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    content: Option<Vec<ContentBlock>>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct UserMessage {
-    #[serde(default)]
-    content: Option<Vec<ToolResult>>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "type")]
-enum ContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        #[serde(default)]
-        input: Option<serde_json::Value>,
-    },
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct ToolResult {
-    #[serde(default)]
-    tool_use_id: Option<String>,
-    #[serde(default)]
-    content: Option<String>,
-}
 
 /// Handle the /claude command
 pub async fn handle_claude(
@@ -585,10 +532,7 @@ async fn process_streaming_json_line(
                     if let Some(content) = user_msg.content {
                         for tool_result in content {
                             if let Some(result_content) = tool_result.content {
-                                let result_message = format!(
-                                    "📋 *Tool result:*\n```\n{}\n```",
-                                    escape_markdown_v2(&result_content)
-                                );
+                                let result_message = create_tool_result_preview(&result_content);
 
                                 bot.send_message(chat_id, result_message)
                                     .parse_mode(ParseMode::MarkdownV2)
@@ -770,6 +714,7 @@ pub fn build_claude_command_args(prompt: &str, conversation_id: Option<&str>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use telegram_bot::claude_code_client::{ClaudeMessage, ContentBlock};
 
     #[test]
     fn test_json_parsing_with_example_output() {
@@ -985,5 +930,48 @@ mod tests {
 
         // Ensure no --resume flag is present
         assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn test_create_tool_result_preview_short_content() {
+        let short_content = "Line 1\nLine 2\nLine 3";
+        let result = create_tool_result_preview(short_content);
+        
+        // Should not be truncated
+        assert!(result.contains("📋 *Tool result:*"));
+        assert!(result.contains("Line 1"));
+        assert!(result.contains("Line 3"));
+        assert!(!result.contains("more lines hidden"));
+    }
+
+    #[test]
+    fn test_create_tool_result_preview_long_content() {
+        // Create content with more than TOOL_RESULT_PREVIEW_LINES
+        let lines: Vec<String> = (1..=30).map(|i| format!("Line {}", i)).collect();
+        let long_content = lines.join("\n");
+        
+        let result = create_tool_result_preview(&long_content);
+        
+        // Should be truncated
+        assert!(result.contains(&format!("showing first {} lines", TOOL_RESULT_PREVIEW_LINES)));
+        assert!(result.contains("more lines hidden"));
+        assert!(result.contains("Line 1"));
+        assert!(result.contains(&format!("Line {}", TOOL_RESULT_PREVIEW_LINES)));
+        assert!(!result.contains(&format!("Line {}", TOOL_RESULT_PREVIEW_LINES + 1)));
+        assert!(result.contains("\\.\\.\\.")); // Truncation indicator
+    }
+
+    #[test]
+    fn test_create_tool_result_preview_exactly_at_limit() {
+        // Create content with exactly TOOL_RESULT_PREVIEW_LINES
+        let lines: Vec<String> = (1..=TOOL_RESULT_PREVIEW_LINES).map(|i| format!("Line {}", i)).collect();
+        let content = lines.join("\n");
+        
+        let result = create_tool_result_preview(&content);
+        
+        // Should not be truncated
+        assert!(result.contains("📋 *Tool result:*"));
+        assert!(!result.contains("more lines hidden"));
+        assert!(!result.contains("\\.\\.\\.")); 
     }
 }


### PR DESCRIPTION
## Summary
- Move Claude streaming JSON types from commands module to claude_code_client module for better organization
- Create new `streaming.rs` module containing `ClaudeMessage`, `AssistantMessage`, `UserMessage`, `ContentBlock`, and `ToolResult` types
- Update imports throughout codebase to use new module location
- Add tool result preview functionality with truncation for long outputs to improve UX

## Changes Made
- **Created** `src/claude_code_client/streaming.rs` with all Claude streaming types
- **Updated** `src/claude_code_client/mod.rs` to export streaming types
- **Refactored** `src/commands/claude.rs` to import types from new location
- **Enhanced** tool result display with truncation for better readability
- **Updated** tests to work with new module structure

## Benefits
- ✅ Improved code organization - streaming types now live in appropriate module
- ✅ Better separation of concerns - command logic separate from data types
- ✅ Cleaner imports and dependencies
- ✅ Enhanced UX with tool result previews
- ✅ All tests pass and code compiles cleanly

## Test Plan
- [x] `cargo check` passes without warnings
- [x] All existing tests continue to pass
- [x] New tool result preview functionality tested
- [x] Module imports work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)