### PR TITLE
Clean up verbose authentication messages

### DIFF
--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -29,12 +29,7 @@ pub async fn handle_auth_state_updates(
             }
             AuthState::UrlReady(url) => {
                 let message =
-                    "🔐 *Claude Account Authentication*\n\nTo complete authentication with your \
-                     Claude account:\n\n*1\\. Click the button below to visit the authentication \
-                     URL*\n\n*2\\. Sign in with your Claude account*\n\n*3\\. Complete the OAuth \
-                     flow in your browser*\n\n*4\\. If prompted for a code, simply paste it here* \
-                     \\(no command needed\\)\n\n✨ This will enable full access to your Claude \
-                     subscription features\\!"
+                    "🔐 *Claude OAuth*\n\nClick below to sign in\\. If prompted for a code, paste it here\\."
                         .to_string();
 
                 let keyboard = InlineKeyboardMarkup::new(vec![vec![InlineKeyboardButton::url(
@@ -52,9 +47,7 @@ pub async fn handle_auth_state_updates(
                 let _ = bot
                     .send_message(
                         chat_id,
-                        "🔑 *Authentication code required*\n\nPlease check your browser for an \
-                         authentication code and paste it directly into this chat\\. No command \
-                         needed\\!",
+                        "🔑 *Code required*\n\nPaste your authentication code here\\.",
                     )
                     .parse_mode(ParseMode::MarkdownV2)
                     .await;

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -139,7 +139,7 @@ async fn handle_auth_status(
         Err(_) => ("Claude Auth: Status unknown ❓".to_string(), false),
     };
 
-    let message = format!("🔐 *Authentication Status*\n\n{}\n{}", github_status, claude_status);
+    let message = format!("🔐 *Auth Status*\n\n{}\n{}", github_status, claude_status);
 
     // Create keyboard based on authentication status
     let mut keyboard_buttons = Vec::new();
@@ -231,7 +231,7 @@ async fn handle_auth_login(
                     status_messages.push("GitHub Auth: Waiting for OAuth completion 🔄".to_string());
                     
                     let github_message = format!(
-                        "🔗 *GitHub OAuth Authentication Required*\n\n*Please follow these steps:*\n\n1️⃣ *Click the button below to visit the authentication URL*\n\n2️⃣ *Enter this device code:*\n```{}```\n\n3️⃣ *Sign in to your GitHub account* and authorize the application\n\n4️⃣ *Return here* \\- authentication will be completed automatically\n\n⏱️ This code will expire in a few minutes\\.",
+                        "🔗 *GitHub OAuth Required*\n\nDevice code: ```{}```\n\nClick below to authorize, then return here\\.",
                         escape_markdown_v2(device_code)
                     );
 
@@ -316,7 +316,7 @@ async fn handle_auth_login(
     }
 
     let summary_message = format!(
-        "🔐 *Authentication Login Results*\n\n{}",
+        "🔐 *Auth Results*\n\n{}",
         status_messages.join("\n")
     );
 


### PR DESCRIPTION
Fixes #131

This PR cleans up the verbose text in `/auth` command output during login workflow:

- Simplified GitHub OAuth message from 4 verbose steps to concise format
- Shortened "Authentication Login Results" to "Auth Results"
- Shortened "Authentication Status" to "Auth Status"
- Simplified Claude OAuth message from verbose 4-step process to concise format
- Shortened authentication code required message

The messages now provide the same essential information but in a much more concise format, improving the user experience during authentication flows.

Generated with [Claude Code](https://claude.ai/code)