### PR TITLE
Fix callback query handling and add debug logging

### DIFF
--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -442,15 +442,21 @@ pub async fn handle_callback_query(
     query: CallbackQuery,
     bot_state: BotState,
 ) -> ResponseResult<()> {
+    log::debug!("Received callback query: {:?}", query);
+    
+    // Always answer the callback query first (this is required by Telegram)
+    bot.answer_callback_query(&query.id).await?;
+    
     if let Some(data) = &query.data {
+        log::debug!("Callback data: {}", data);
+        
         if let Some(message) = &query.message {
             let chat_id = message.chat().id;
-
-            // Answer the callback query first to remove the loading state
-            bot.answer_callback_query(&query.id).await?;
+            log::debug!("Chat ID: {}", chat_id.0);
 
             match data.as_str() {
                 "auth_login" => {
+                    log::debug!("Handling auth_login callback for chat {}", chat_id.0);
                     // Handle auth login callback
                     let container_name = format!("coding-session-{}", chat_id.0);
                     match ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name)
@@ -487,6 +493,7 @@ Please start a coding session \
                     }
                 }
                 data if data.starts_with("clone:") => {
+                    log::debug!("Handling clone callback for chat {}", chat_id.0);
                     // Extract repository name from callback data
                     let repository = data.strip_prefix("clone:").unwrap_or("");
                     let container_name = format!("coding-session-{}", chat_id.0);
@@ -536,6 +543,7 @@ Please start a coding session \
                     }
                 }
                 data if data.starts_with("start_clone:") => {
+                    log::debug!("Handling start_clone callback for chat {}", chat_id.0);
                     // Extract repository name from callback data for start workflow
                     let repository = data.strip_prefix("start_clone:").unwrap_or("");
                     if let Err(e) = commands::start::handle_repository_clone_in_start(
@@ -557,14 +565,17 @@ Please start a coding session \
                     }
                 }
                 "manual_repo_entry" => {
+                    log::debug!("Handling manual_repo_entry callback for chat {}", chat_id.0);
                     // Handle manual repository entry
                     commands::start::handle_manual_repository_entry(bot, chat_id).await?;
                 }
                 "skip_repo_setup" => {
+                    log::debug!("Handling skip_repo_setup callback for chat {}", chat_id.0);
                     // Handle skipping repository setup
                     commands::start::handle_skip_repository_setup(bot, chat_id).await?;
                 }
                 "github_repo_list" => {
+                    log::debug!("Handling github_repo_list callback for chat {}", chat_id.0);
                     // Handle github repo list callback
                     let container_name = format!("coding-session-{}", chat_id.0);
                     match ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name)
@@ -597,16 +608,15 @@ Please start a coding session \
                     }
                 }
                 _ => {
+                    log::debug!("Unknown callback data '{}' for chat {}", data, chat_id.0);
                     // Unknown callback data, already answered above
                 }
             }
         } else {
-            // No message, just answer the query
-            bot.answer_callback_query(&query.id).await?;
+            log::debug!("Callback query has no message");
         }
     } else {
-        // No callback data, just answer the query
-        bot.answer_callback_query(&query.id).await?;
+        log::debug!("Callback query has no data");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Fix callback query handling by restructuring dispatcher handler to properly handle both Message and CallbackQuery updates at top level
- Add comprehensive debug logging to callback query handler for better debugging
- Ensure callback queries are always answered immediately as required by Telegram API

## Problem
The callback query filter was nested under the message filter in the dispatcher handler, causing teloxide to only request `[Message]` updates from Telegram instead of `[CallbackQuery, Message]`. This meant that inline keyboard button presses were not being received by the bot.

## Solution
- Restructured the dispatcher handler to have separate top-level branches for messages and callback queries
- Added debug logging throughout the callback handler to help with future debugging
- Moved `bot.answer_callback_query()` to be called immediately upon receiving any callback query

## Changes
- **src/main.rs**: Restructured handler from nested structure to proper branching
- **src/bot/handlers.rs**: Added comprehensive debug logging and improved callback query answering

## Test Plan
- [x] Bot correctly shows `hinting allowed updates: [CallbackQuery, Message]` in debug logs
- [x] Inline keyboard buttons (clone repository) now work properly
- [x] Debug logs show callback queries being received and processed
- [x] Repository cloning via callback buttons functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)