### PR TITLE
Add working directory tracking for cloned repositories

### DIFF
--- a/src/bot/claude_session.rs
+++ b/src/bot/claude_session.rs
@@ -9,6 +9,7 @@ pub struct ClaudeSession {
     pub conversation_id: Option<String>,
     pub process_handle: Option<Child>,
     pub is_active: bool,
+    pub working_directory: Option<String>,
 }
 
 impl ClaudeSession {
@@ -17,6 +18,7 @@ impl ClaudeSession {
             conversation_id: None,
             process_handle: None,
             is_active: false,
+            working_directory: None,
         }
     }
 
@@ -38,6 +40,14 @@ impl ClaudeSession {
     pub fn reset_conversation(&mut self) {
         self.stop_conversation();
         self.conversation_id = None;
+    }
+
+    pub fn set_working_directory(&mut self, directory: String) {
+        self.working_directory = Some(directory);
+    }
+
+    pub fn get_working_directory(&self) -> Option<&String> {
+        self.working_directory.as_ref()
     }
 }
 

--- a/src/bot/handlers.rs
+++ b/src/bot/handlers.rs
@@ -524,6 +524,7 @@ Please start a coding session \
                                 chat_id,
                                 &github_client,
                                 repository,
+                                &bot_state,
                             )
                             .await?;
                         }

--- a/src/claude_code_client/mod.rs
+++ b/src/claude_code_client/mod.rs
@@ -276,6 +276,15 @@ impl ClaudeCodeClient {
         docker: Docker,
         container_name: &str,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::for_session_with_working_dir(docker, container_name, None).await
+    }
+
+    /// Helper method to create a client for a coding session with custom working directory
+    pub async fn for_session_with_working_dir(
+        docker: Docker,
+        container_name: &str,
+        working_directory: Option<String>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Find the container by name
         let containers = docker
             .list_containers(None::<bollard::container::ListContainersOptions<String>>)
@@ -301,7 +310,12 @@ impl ClaudeCodeClient {
             .ok_or("Container ID not found")?
             .clone();
 
-        Ok(Self::new(docker, container_id, ClaudeCodeConfig::default()))
+        let mut config = ClaudeCodeConfig::default();
+        if let Some(dir) = working_directory {
+            config.working_directory = Some(dir);
+        }
+
+        Ok(Self::new(docker, container_id, config))
     }
 
     /// Create a client with custom OAuth configuration

--- a/src/commands/claude.rs
+++ b/src/commands/claude.rs
@@ -80,7 +80,20 @@ pub async fn execute_claude_command(
     );
 
     let container_name = format!("coding-session-{}", chat_id.0);
-    let client = ClaudeCodeClient::for_session(bot_state.docker.clone(), &container_name).await?;
+    
+    // Get working directory from session state
+    let working_directory = {
+        let claude_sessions = bot_state.claude_sessions.lock().await;
+        claude_sessions
+            .get(&chat_id.0)
+            .and_then(|session| session.get_working_directory().cloned())
+    };
+    
+    let client = ClaudeCodeClient::for_session_with_working_dir(
+        bot_state.docker.clone(), 
+        &container_name, 
+        working_directory
+    ).await?;
 
     // Execute Claude prompt with streaming or batch processing
     match client


### PR DESCRIPTION
## Summary
- Track the last GitHub repository cloned as the working directory for all subsequent /claude commands at the session level
- Enhance user experience by automatically setting context for Claude commands after repository cloning
- Maintain proper session isolation between different users

## Changes
- Add `working_directory` field to `ClaudeSession` state with getter/setter methods
- Update GitHub clone operations to automatically set working directory after successful clone
- Enhance `ClaudeCodeClient` with `for_session_with_working_dir` method for custom working directories
- Modify Claude command execution to retrieve and use session working directory
- Update user notifications to indicate working directory has been set

## Test plan
- [ ] Clone a GitHub repository and verify working directory is set in session
- [ ] Run /claude commands and verify they execute in the cloned repository context
- [ ] Test with multiple users to ensure session isolation
- [ ] Verify backward compatibility with existing functionality
- [ ] Test that working directory persists across the session until new repository is cloned

🤖 Generated with [Claude Code](https://claude.ai/code)