### PR TITLE
Fix working directory absolute path handling for Docker exec

### DIFF
--- a/src/claude_code_client/mod.rs
+++ b/src/claude_code_client/mod.rs
@@ -312,7 +312,13 @@ impl ClaudeCodeClient {
 
         let mut config = ClaudeCodeConfig::default();
         if let Some(dir) = working_directory {
-            config.working_directory = Some(dir);
+            // Ensure working directory is absolute for Docker exec
+            let absolute_dir = if std::path::Path::new(&dir).is_absolute() {
+                dir
+            } else {
+                format!("/workspace/{}", dir)
+            };
+            config.working_directory = Some(absolute_dir);
         }
 
         Ok(Self::new(docker, container_id, config))

--- a/src/claude_code_client/mod.rs
+++ b/src/claude_code_client/mod.rs
@@ -316,7 +316,9 @@ impl ClaudeCodeClient {
             let absolute_dir = if std::path::Path::new(&dir).is_absolute() {
                 dir
             } else {
-                format!("/workspace/{}", dir)
+                // Use the config's default working directory as the base instead of hardcoding
+                let base_dir = config.working_directory.as_deref().unwrap_or("/workspace");
+                format!("{}/{}", base_dir, dir)
             };
             config.working_directory = Some(absolute_dir);
         }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -67,7 +67,15 @@ pub async fn perform_github_clone(
                     claude_sessions
                         .entry(chat_id.0)
                         .or_insert_with(|| crate::bot::claude_session::ClaudeSession::new())
-                        .set_working_directory(clone_result.target_directory.clone());
+                        .set_working_directory(
+                            std::path::Path::new(&clone_result.target_directory)
+                                .canonicalize()
+                                .unwrap_or_else(|_| {
+                                    std::path::PathBuf::from(&clone_result.target_directory)
+                                })
+                                .to_string_lossy()
+                                .to_string(),
+                        );
                 }
 
                 format!(


### PR DESCRIPTION
## Summary
• Fixed "Cwd must be an absolute path" error when executing Claude commands in cloned repositories
• Ensured working directories are properly converted to absolute paths for Docker exec operations
• Added path canonicalization when storing cloned repository directories in session state

## Test plan
- [x] Verified container creation and authentication flows work correctly
- [x] Tested repository cloning sets working directory properly  
- [x] Confirmed Claude commands execute successfully with absolute working directory
- [x] Validated no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)