### PR TITLE
Fix comments in pull request 150

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -142,6 +142,10 @@ pub async fn handle_commit(
     let commit_message = match claude_result {
         Ok(output) => {
             let generated_message = output.trim();
+            // If Claude returned an *empty* string we fall back to a plain
+            // "Add changes" message *without* the checkpoint prefix.  We only
+            // attach the "Claude Code Checkpoint:" prefix when Claude
+            // produced a non-empty summary.
             if generated_message.is_empty() {
                 "Add changes".to_string()
             } else {

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -142,10 +142,6 @@ pub async fn handle_commit(
     let commit_message = match claude_result {
         Ok(output) => {
             let generated_message = output.trim();
-            // If Claude returned an *empty* string we fall back to a plain
-            // "Add changes" message *without* the checkpoint prefix.  We only
-            // attach the "Claude Code Checkpoint:" prefix when Claude
-            // produced a non-empty summary.
             if generated_message.is_empty() {
                 "Add changes".to_string()
             } else {


### PR DESCRIPTION
Refine `/commit` command's status reporting and commit message generation to fix two regressions.

The previous `/commit` logic incorrectly reported a "clean" working directory when changes were merely committed, and failed to properly fall back when `git diff --cached` errored. This PR introduces a `get_git_diff` helper to accurately detect all types of changes and distinguish between a truly clean state and an "all changes committed" state, while also making the diff retrieval more robust. Additionally, the commit message generation no longer prefixes "Claude Code Checkpoint:" when Claude returns an empty string, reverting to the intended "Add changes" in that scenario.